### PR TITLE
Add Docker Compose configurations for BookStack, PostgreSQL, and FerretDB

### DIFF
--- a/bookstack/README.md
+++ b/bookstack/README.md
@@ -1,0 +1,49 @@
+โปรเจกต์นี้ใช้สำหรับติดตั้ง BookStack และฐานข้อมูล MariaDB ผ่าน Docker Compose
+
+## วิธีการติดตั้ง
+
+### 1. เตรียมเครื่อง
+- ติดตั้ง Docker และ Docker Compose ให้เรียบร้อย
+- Clone โปรเจกต์นี้มาที่เครื่อง
+
+### 2. ตรวจสอบ/แก้ไขค่าต่าง ๆ ใน `docker-compose.yml`
+- `APP_URL` กำหนด URL สำหรับเรียกใช้งาน (เช่น http://localhost:6875)
+- ตรวจสอบ `APP_KEY` ว่าถูกต้อง หากไม่มีกำหนดให้เข้า container แล้วรัน:
+  ```
+  docker exec -it bookstack php artisan key:generate --show
+  ```
+  แล้วนำค่าที่ได้ไปใส่ใน `APP_KEY`
+- ตรวจสอบชื่อฐานข้อมูล, ชื่อผู้ใช้ และรหัสผ่านให้ตรงกันระหว่าง `bookstack` และ `mariadb`
+
+### 3. สั่งรัน container
+```
+docker-compose up -d
+```
+
+### 4. การเข้าใช้งาน
+- เปิดเว็บเบราว์เซอร์ไปที่ [http://localhost:6875](http://localhost:6875)
+
+### 5. การหยุดและลบ container
+```
+docker-compose down
+```
+
+### 6. การสำรองข้อมูล
+- ข้อมูลของแอปจะถูกเก็บไว้ที่โฟลเดอร์:
+  - `./bookstack_app_data`
+  - `./bookstack_db_data`
+- ควรสำรองโฟลเดอร์เหล่านี้เป็นระยะ ๆ
+
+---
+
+> **Tip**: หากมีการเปลี่ยนแปลงเวอร์ชัน ให้แก้ไข `image` เวอร์ชัน ใน `docker-compose.yml` แล้วสั่ง:
+```
+docker-compose pull
+docker-compose up -d
+```
+
+## Auth
+```bash
+admin@admin.com
+password
+```

--- a/bookstack/docker-compose.yml
+++ b/bookstack/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  bookstack:
+    image: lscr.io/linuxserver/bookstack:version-v25.02
+    container_name: bookstack
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Asia/Bangkok
+      - APP_URL=http://localhost:6875
+      - APP_KEY=base64:3qjlIoUX4Tw6fUQgZcxMbz6lb8+dAzqpvItqHvahW1c=
+      - DB_HOST=mariadb
+      - DB_PORT=3306
+      - DB_DATABASE=bookstack
+      - DB_USERNAME=bookstack
+      - DB_PASSWORD=bookstack8432
+    volumes:
+      - ./bookstack_app_data:/config
+    ports:
+      - 6875:80
+    restart: unless-stopped
+  mariadb:
+    image: lscr.io/linuxserver/mariadb:11.4.4
+    container_name: mariadb
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Asia/Bangkok
+      - MYSQL_ROOT_PASSWORD=mysupersecretrootpassword
+      - MYSQL_DATABASE=bookstack
+      - MYSQL_USER=bookstack
+      - MYSQL_PASSWORD=bookstack8432
+    volumes:
+      - ./bookstack_db_data:/config
+    # ports:
+    #   - 3306:3306
+    restart: unless-stopped

--- a/ferretdb/README.md
+++ b/ferretdb/README.md
@@ -1,0 +1,7 @@
+## FerretDB
+```bash
+docker compose up -d
+
+// connect mongosh
+mongodb://username:password@127.0.0.1/
+```

--- a/ferretdb/docker-compose.yml
+++ b/ferretdb/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  postgres:
+    image: ghcr.io/ferretdb/postgres-documentdb:17-0.102.0-ferretdb-2.0.0
+    platform: linux/amd64
+    restart: on-failure
+    environment:
+      - POSTGRES_USER=username
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+    volumes:
+      - ./data:/var/lib/postgresql/data
+
+  ferretdb:
+    image: ghcr.io/ferretdb/ferretdb:2.0.0
+    restart: on-failure
+    ports:
+      - 27017:27017
+    environment:
+      - FERRETDB_POSTGRESQL_URL=postgres://username:password@postgres:5432/postgres
+
+networks:
+  default:
+    name: ferretdb

--- a/postgres-pgvector/docker-compose.yml
+++ b/postgres-pgvector/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  db:
+    image: pgvector/pgvector:pg17 # PostgreSQL with pgvector support
+    container_name: pgvector-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: example_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./postgres/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Introduce Docker Compose setups for BookStack with MariaDB, PostgreSQL with pgvector support, and FerretDB, along with installation instructions and usage guidelines.