### PR TITLE
Add JSON Crack submodule and update README instructions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jsoncrack"]
+	path = jsoncrack
+	url = https://github.com/AykutSarac/jsoncrack.com.git

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can start, stop, and manage these services independently, making it easy to 
 | infisical             | Infisical            | Secret management for developers |
 | jenkins               | Jenkins              | Automation server for CI/CD |
 | jsreport              | jsreport             | Reporting platform for generating PDFs, etc. |
+| jsoncrack             | JSON Crack           | Visual JSON data explorer and editor |
 | kong                  | Kong                 | API gateway and management |
 | minio                 | MinIO                | High-performance object storage (S3 compatible) |
 | mongodb               | MongoDB              | NoSQL document database |
@@ -63,6 +64,7 @@ hashicorp-vault/
 infisical/
 jenkins/
 jsreport/
+jsoncrack/
 kong/
 minio/
 mongodb/
@@ -111,6 +113,127 @@ To add a new service or update an existing one, follow these guidelines:
 8. **(Optional) Add environment example files** (e.g., `.env.example`) if your service requires environment variables.
 
 By following these conventions, the project will remain organized and easy to maintain.
+
+## Working with Git Submodules
+
+This project uses Git submodules to include external repositories. Submodules allow us to keep external projects as separate repositories while including them in our main project.
+
+### What is a Submodule?
+
+A Git submodule is a repository embedded inside another repository. It maintains its own history and can be updated independently. In this project, we use submodules for services that have their own upstream repositories (e.g., `jsoncrack`).
+
+### Initial Setup (First Time Clone)
+
+If you're cloning this repository for the first time and want to include all submodules:
+
+```bash
+# Clone with all submodules
+git clone --recurse-submodules https://github.com/abcprintf/docker-setup-dev.git
+
+# OR if you already cloned without submodules
+git clone https://github.com/abcprintf/docker-setup-dev.git
+cd docker-setup-dev
+git submodule init
+git submodule update
+```
+
+### Adding a New Submodule
+
+To add a new external repository as a submodule:
+
+```bash
+# Add submodule
+git submodule add <repository-url> <folder-name>
+
+# Example:
+git submodule add https://github.com/AykutSarac/jsoncrack.com.git jsoncrack
+
+# Commit the changes
+git add .gitmodules <folder-name>
+git commit -m "Add <service-name> submodule"
+git push
+```
+
+### Updating Submodules
+
+To update a submodule to the latest version from its repository:
+
+```bash
+# Update specific submodule to latest
+cd <submodule-folder>
+git pull origin main  # or master, depending on the branch
+
+# Go back to main project and commit the update
+cd ..
+git add <submodule-folder>
+git commit -m "Update <submodule-name> to latest version"
+git push
+```
+
+Or update all submodules at once:
+
+```bash
+# Update all submodules to their latest commits
+git submodule update --remote --merge
+
+# Commit the updates
+git add .
+git commit -m "Update all submodules"
+git push
+```
+
+### Checking Submodule Status
+
+```bash
+# View submodule status
+git submodule status
+
+# View submodule configuration
+cat .gitmodules
+```
+
+### Removing a Submodule
+
+If you need to remove a submodule:
+
+```bash
+# Remove the submodule entry from .git/config
+git submodule deinit -f <submodule-folder>
+
+# Remove the submodule from the working tree and .git/modules
+git rm -f <submodule-folder>
+
+# Commit the changes
+git commit -m "Remove <submodule-name> submodule"
+git push
+```
+
+### Common Submodule Issues
+
+**Issue: Submodule folder is empty after clone**
+```bash
+git submodule init
+git submodule update
+```
+
+**Issue: Detached HEAD in submodule**
+```bash
+cd <submodule-folder>
+git checkout main  # or the branch you want
+cd ..
+```
+
+**Issue: Submodule changes not tracked**
+- Submodules are tracked as specific commits, not branches
+- After updating inside a submodule, return to the parent repository and commit the change
+
+### Best Practices
+
+1. **Always commit submodule updates** in the parent repository after updating the submodule
+2. **Document which branch** each submodule should track (usually `main` or `master`)
+3. **Communicate with team** when updating submodules to avoid conflicts
+4. **Use `--recurse-submodules`** flag when cloning to automatically initialize submodules
+5. **Check submodule status** regularly with `git submodule status`
 
 ## Contributing & Reporting Issues
 

--- a/README_TH.md
+++ b/README_TH.md
@@ -23,6 +23,7 @@
 | infisical               | Infisical                 | จัดการ secret สำหรับนักพัฒนา |
 | jenkins                 | Jenkins                   | ระบบ automation สำหรับ CI/CD |
 | jsreport                | jsreport                  | ระบบสร้างรายงานและไฟล์ PDF |
+| jsoncrack               | JSON Crack                | เครื่องมือดูและแก้ไข JSON แบบ visual |
 | kong                    | Kong                      | API gateway และจัดการ API |
 | minio                   | MinIO                     | ระบบ object storage ที่ compatible กับ S3 |
 | mongodb                 | MongoDB                   | ฐานข้อมูล NoSQL แบบ document |
@@ -64,6 +65,7 @@ hashicorp-vault/
 infisical/
 jenkins/
 jsreport/
+jsoncrack/
 kong/
 minio/
 mongodb/
@@ -108,6 +110,127 @@ windows/
 6. **ใช้ตัวพิมพ์เล็กและขีดกลาง** (lowercase, hyphen) ในชื่อโฟลเดอร์/ไฟล์
 7. **ทดสอบ service** ด้วย `docker-compose up` ให้แน่ใจว่าใช้งานได้
 8. **(ถ้ามี) เพิ่มไฟล์ตัวอย่าง env** เช่น `.env.example`
+
+## การใช้งาน Git Submodules
+
+โปรเจกต์นี้ใช้ Git submodules เพื่อรวม repository ภายนอกเข้ามา Submodules ช่วยให้เราสามารถเก็บโปรเจกต์ภายนอกเป็น repository แยกต่างหากในขณะที่รวมอยู่ในโปรเจกต์หลักของเรา
+
+### Submodule คืออะไร?
+
+Git submodule คือ repository ที่ฝังอยู่ในอีก repository หนึ่ง มันมี history ของตัวเองและสามารถอัปเดตแยกอิสระได้ ในโปรเจกต์นี้ เราใช้ submodules สำหรับบริการที่มี upstream repository ของตัวเอง (เช่น `jsoncrack`)
+
+### การตั้งค่าครั้งแรก (Clone ครั้งแรก)
+
+หากคุณกำลัง clone repository นี้ครั้งแรกและต้องการรวม submodules ทั้งหมด:
+
+```bash
+# Clone พร้อมกับ submodules ทั้งหมด
+git clone --recurse-submodules https://github.com/abcprintf/docker-setup-dev.git
+
+# หรือถ้า clone ไปแล้วโดยไม่มี submodules
+git clone https://github.com/abcprintf/docker-setup-dev.git
+cd docker-setup-dev
+git submodule init
+git submodule update
+```
+
+### การเพิ่ม Submodule ใหม่
+
+เพื่อเพิ่ม repository ภายนอกเป็น submodule:
+
+```bash
+# เพิ่ม submodule
+git submodule add <repository-url> <folder-name>
+
+# ตัวอย่าง:
+git submodule add https://github.com/AykutSarac/jsoncrack.com.git jsoncrack
+
+# Commit การเปลี่ยนแปลง
+git add .gitmodules <folder-name>
+git commit -m "Add <service-name> submodule"
+git push
+```
+
+### การอัปเดต Submodules
+
+เพื่ออัปเดต submodule ให้เป็นเวอร์ชันล่าสุดจาก repository ต้นทาง:
+
+```bash
+# อัปเดต submodule เฉพาะตัวเป็นเวอร์ชันล่าสุด
+cd <submodule-folder>
+git pull origin main  # หรือ master ขึ้นกับชื่อ branch
+
+# กลับไปที่โปรเจกต์หลักและ commit การอัปเดต
+cd ..
+git add <submodule-folder>
+git commit -m "Update <submodule-name> to latest version"
+git push
+```
+
+หรืออัปเดต submodules ทั้งหมดพร้อมกัน:
+
+```bash
+# อัปเดต submodules ทั้งหมดเป็น commit ล่าสุด
+git submodule update --remote --merge
+
+# Commit การอัปเดต
+git add .
+git commit -m "Update all submodules"
+git push
+```
+
+### ตรวจสอบสถานะ Submodule
+
+```bash
+# ดูสถานะ submodule
+git submodule status
+
+# ดูการตั้งค่า submodule
+cat .gitmodules
+```
+
+### การลบ Submodule
+
+หากต้องการลบ submodule:
+
+```bash
+# ลบ entry ของ submodule จาก .git/config
+git submodule deinit -f <submodule-folder>
+
+# ลบ submodule จาก working tree และ .git/modules
+git rm -f <submodule-folder>
+
+# Commit การเปลี่ยนแปลง
+git commit -m "Remove <submodule-name> submodule"
+git push
+```
+
+### ปัญหาที่พบบ่อยกับ Submodule
+
+**ปัญหา: โฟลเดอร์ submodule ว่างเปล่าหลัง clone**
+```bash
+git submodule init
+git submodule update
+```
+
+**ปัญหา: Detached HEAD ใน submodule**
+```bash
+cd <submodule-folder>
+git checkout main  # หรือ branch ที่ต้องการ
+cd ..
+```
+
+**ปัญหา: การเปลี่ยนแปลงใน submodule ไม่ถูก track**
+- Submodules ถูก track เป็น commit เฉพาะ ไม่ใช่ branch
+- หลังจากอัปเดตใน submodule ต้องกลับมาที่ parent repository และ commit การเปลี่ยนแปลง
+
+### แนวทางปฏิบัติที่ดี
+
+1. **ควร commit การอัปเดต submodule เสมอ** ใน parent repository หลังจากอัปเดต submodule
+2. **จดบันทึกว่า branch ไหน** ที่แต่ละ submodule ควร track (โดยทั่วไปคือ `main` หรือ `master`)
+3. **สื่อสารกับทีม** เมื่อมีการอัปเดต submodules เพื่อหลีกเลี่ยง conflicts
+4. **ใช้ flag `--recurse-submodules`** เมื่อ clone เพื่อ initialize submodules โดยอัตโนมัติ
+5. **ตรวจสอบสถานะ submodule เป็นประจำ** ด้วย `git submodule status`
 
 ## การ contribute หรือแจ้งปัญหา
 


### PR DESCRIPTION
Add the JSON Crack service as a Git submodule and include detailed instructions in the README for working with Git submodules. This enhances the project's documentation and facilitates easier integration of external services.